### PR TITLE
New ground b function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 
 install: 
   - pip install -r ../requirements.txt 
-  - pip install flake8 pytest pytest-cov
+  - pip install flake8 pytest==3.0.7 pytest-cov==2.6.0
 
 before_script:
   cd ..

--- a/pyamps/amps.py
+++ b/pyamps/amps.py
@@ -1125,19 +1125,21 @@ class AMPS(object):
         return G.dot(np.vstack((self.pol_c, self.pol_s)))
 
 
-    def get_ground_perturbation(self, mlat, mlt, height = 0):
+    def get_ground_perturbation(self, mlat = DEFAULT, mlt = DEFAULT, height = 0):
         """ 
         Calculate magnetic field perturbations on ground, in units of nT, that corresponds 
         to the divergence-free current function.
 
         Parameters
         ----------
-        mlat : numpy.ndarray, float
+        mlat : numpy.ndarray, float, optional
             magnetic latitude of the output. The array shape will not be preserved, and 
-            the results will be returned as a 1-dimensional array
-        mlt : numpy.ndarray, float
+            the results will be returned as a 1-dimensional array. Default value is 
+            from self.vectorgrid
+        mlt : numpy.ndarray, float, optional
             magnetic local time of the output. The array shape will not be preserved, and 
-            the results will be returned as a 1-dimensional array
+            the results will be returned as a 1-dimensional array. Default value is 
+            from self.vectorgrid
         height: numpy.ndarray, optional
             geodetic height at which the field should be evalulated. Should be < current height
             set at initialization. Default 0 (ground)
@@ -1172,6 +1174,10 @@ class AMPS(object):
            Journal of geomagnetism and geoelectricity Vol. 47, 1995, http://doi.org/10.5636/jgg.47.191
 
         """
+
+        # if mlat and mlt are not given, call function again with vectorgrid
+        if mlat is DEFAULT or mlt is DEFAULT:
+            return self.get_ground_perturbation(self.vectorgrid[0], self.vectorgrid[1], height = height)
 
         mlt  = mlt. flatten()[:, np.newaxis]
         mlat = mlat.flatten()[:, np.newaxis]

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,9 +60,7 @@ exclude =
 dev = 
     sphinx>=1.3
     sphinx_pypi_upload
-test = 
-    pytest==3.0.7
-    pytest-cov==2.6.0
+test = pytest
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,8 +61,8 @@ dev =
     sphinx>=1.3
     sphinx_pypi_upload
 test = 
-    pytest
-    pytest-cov<2.6.0
+    pytest==3.0.7
+    pytest-cov==2.6.0
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,9 @@ exclude =
 dev = 
     sphinx>=1.3
     sphinx_pypi_upload
-test = pytest
+test = 
+    pytest
+    pytest-cov
 
 [build_sphinx]
 source-dir = docs/source

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     sphinx_pypi_upload
 test = 
     pytest
-    pytest-cov
+    pytest-cov<2.6.0
 
 [build_sphinx]
 source-dir = docs/source


### PR DESCRIPTION
Changed AMPS.get_ground_perturbation function so that it can be called without any function arguments. In that case, the return values are evaluated on the coordinates defined in the object's vectorgrid parameter