### PR TITLE
Fixing filename "magic constants"

### DIFF
--- a/pyamps/coefficients/__init__.py
+++ b/pyamps/coefficients/__init__.py
@@ -1,0 +1,24 @@
+"""
+  Model coefficients files
+
+"""
+
+import os.path
+
+_PATH = os.path.abspath(os.path.dirname(__file__))
+
+MODEL_VECTOR_TEST = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3.npy")
+MODEL_VECTOR_0100 = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3__v1.0.npy")
+MODEL_VECTOR_0101 = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3__v1.1.npy")
+MODEL_VECTOR_0103 = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3__v1.3.npy")
+MODEL_VECTOR_0104 = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3__v1.4.npy")
+MODEL_VECTOR_0105 = os.path.join(_PATH, "model_vector_NT_MT_NV_MV_65_3_45_3__v1.5.npy")
+MODEL_VECTOR_LATEST = MODEL_VECTOR_0105
+
+MODEL_COEFF_TEST = os.path.join(_PATH, "test_model.txt")
+MODEL_COEFF_0101 = os.path.join(_PATH, "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0101.txt")
+MODEL_COEFF_0102 = os.path.join(_PATH, "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0102.txt")
+MODEL_COEFF_0103 = os.path.join(_PATH, "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0103.txt")
+MODEL_COEFF_0104 = os.path.join(_PATH, "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0104.txt")
+MODEL_COEFF_0105 = os.path.join(_PATH, "SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0105.txt")
+MODEL_COEFF_LATEST = MODEL_COEFF_0105

--- a/pyamps/model_utils.py
+++ b/pyamps/model_utils.py
@@ -1,11 +1,9 @@
 import numpy as np
 import pandas as pd
-import os
 from functools import reduce
+from .coefficients import MODEL_COEFF_LATEST
 
-basepath = os.path.dirname(__file__)
-
-default_coeff_fn = os.path.abspath(os.path.join(basepath,'coefficients','SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0104.txt'))
+default_coeff_fn = MODEL_COEFF_LATEST
 
 # read coefficient file and store in pandas DataFrame - with column names from last row of header:
 colnames = ([x for x in open(default_coeff_fn).readlines() if x.startswith('#')][-1][1:]).strip().split(' ') 

--- a/pyamps/model_vector_to_txt.py
+++ b/pyamps/model_vector_to_txt.py
@@ -6,11 +6,11 @@
     no longer useful.
 """
 from __future__ import absolute_import
-import os.path
 import time
 import numpy as np
 import pandas as pd
 from sh_utils import SHkeys
+from .coefficients import MODEL_VECTOR_LATEST, MODEL_COEFF_LATEST
 
 # header
 t = time.ctime().split(' ')
@@ -33,10 +33,8 @@ header = header + """
 """
 
 
-basepath = os.path.dirname(__file__)
-
 # load model vector and define truncation levels and external parametrisation
-model_vector = np.load(os.path.abspath(os.path.join(basepath,'coefficients/model_vector_NT_MT_NV_MV_65_3_45_3__v1.5.npy')))
+model_vector = np.load(MODEL_VECTOR_LATEST)
 NT, MT, NV, MV = 65, 3, 45, 3
 
 external_parameters = ['const', 'sinca', 'cosca', 'epsilon', 'epsilon_sinca', 'epsilon_cosca', 'tilt', 
@@ -82,11 +80,10 @@ for m, param in zip(dataframes, external_parameters):
 coefficients = pd.concat(dataframes, axis = 1)
 
 # write txt file
-with open(os.path.abspath(os.path.join(basepath,'coefficients/SW_OPER_MIO_SHA_2E_00000000T000000_99999999T999999_0105.txt')), 'w') as file:
+with open(MODEL_COEFF_LATEST, 'w') as file:
     # header:
     file.write(header)
     # data:
     coefficients.to_string(buf = file, float_format = lambda x: '{:.7f}'.format(x), 
                            header = False, sparsify = False,
                            index_names = False)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@
 
 import pytest
 import sys
-import os
 
 import pandas as pd
 
 import pyamps
+from pymps.coefficients import MODEL_COEFF_TEST
 
 
 def pytest_runtest_makereport(item, call):
@@ -47,9 +47,8 @@ def model_coeff():
     """Generate test data similar in form to AMPS model coefficients"""
 
     true_name = pyamps.model_utils.default_coeff_fn
-    fake_name = os.path.abspath(os.path.join(pyamps.model_utils.basepath,'coefficients','test_model.txt'))
+    fake_name = MODEL_COEFF_TEST
     pyamps.model_utils.default_coeff_fn = fake_name
-
 
     yield fake_name
     #yield true_name, fake_name

--- a/tests/test_amps.py
+++ b/tests/test_amps.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import os
 import pytest
 import datetime
 import numpy as np
@@ -10,8 +9,9 @@ from numpy.testing import assert_array_equal, assert_allclose
 import pyamps
 from pyamps.amps import AMPS, get_B_space, get_B_ground
 from pyamps import model_utils
+from pymps.coefficients import MODEL_COEFF_TEST
 
-test_coeff_fn = os.path.abspath(os.path.join(model_utils.basepath,'coefficients','test_model.txt'))
+test_coeff_fn = MODEL_COEFF_TEST
 
 @pytest.fixture()
 def amps_model(model_coeff):

--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,14 +1,14 @@
 from __future__ import division
 
-import os
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 import pyamps
+from pymps.coefficients import MODEL_COEFF_TEST
 
 def test_model_vectors():
 
-    fn = os.path.abspath(os.path.join(pyamps.model_utils.basepath, 'coefficients','test_model.txt'))
+    fn = MODEL_COEFF_TEST
 
     model_vectors = pyamps.model_utils.get_model_vectors(v=0, By=0, Bz=1, tilt=0.5, f107=0.3, coeff_fn = fn)
     # const,cosca,tilt and f107 terms non-zero

--- a/tests/test_model_vector_to_txt.py
+++ b/tests/test_model_vector_to_txt.py
@@ -6,13 +6,14 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
 import pyamps
+from pymps.coefficients import MODEL_VECTOR_TEST, MODEL_COEFF_TEST
 
 
 def test_get_model_vectors():
     basepath = os.path.join(os.path.dirname(__file__), "..", "pyamps")
-    model_vector = np.load(os.path.abspath(os.path.join(basepath, 'coefficients/model_vector_NT_MT_NV_MV_65_3_45_3.npy')))
+    model_vector = np.load(MODEL_VECTOR_TEST)
 
-    path_txt = os.path.abspath(os.path.join(basepath, 'coefficients/model_coefficients.txt'))
+    path_txt = MODEL_COEFF_TEST
     assert os.path.exists(path_txt)
     
     coeffs = np.nan_to_num(np.genfromtxt(path_txt, skip_header=14, unpack=True))
@@ -20,5 +21,3 @@ def test_get_model_vectors():
     
     assert_allclose(model_vectors[0][:len(coeffs[0])], coeffs[2], atol=1e-6)
     assert_allclose(model_vector.sum(), coeffs[2:].sum(), atol=1e-5)
-
-    pass


### PR DESCRIPTION
This PR fixes the default coefficients to be of the latest 1.5 version (#17) and eliminates duplicated magic filenames scattered over different files and confines them in one place, hopefully, preventing the same issue happening in the future.

Storing the filesnames in variables should also help users to evaluate the models with the included older coefficient files without a need for clumsy filename constructions.